### PR TITLE
Gate the bidirectional Rust interop example and document two diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- Extended the `example-checks` and `example-fmt` quality gates to the
+  bidirectional Native Rust interoperability example
+  `examples/calculator-rust/callback.spx`, which declares an `import rust fn`
+  callback and the export that calls it. That source was previously outside
+  both loops, so its verification and canonical formatting were ungated.
+  Documented the already emitted `SPX-B112` SDK admission and `SPX-I233` SDK
+  publication diagnostics in
+  [Native Rust Interoperability v1](docs/NATIVE-RUST-INTEROP-V1.md), whose
+  owned-diagnostic list had omitted both. No admitted source form, type, ABI,
+  descriptor, manifest, or generated-artifact byte changed.
+
 - Widened the Public Scalar Export Profile v1 from `i64`/`bool` to the full
   Copy-scalar surface — `i64`, `i32`, `u8`, `char`, `f32`, `f64`, `bool` —
   matching the surface the reference interpreter, `semaprax.abi-report.v1`,

--- a/docs/NATIVE-RUST-INTEROP-V1.md
+++ b/docs/NATIVE-RUST-INTEROP-V1.md
@@ -367,9 +367,9 @@ builder output.
 
 The exact owned diagnostics are B106 noncanonical spec; B107 closed declaration
 reason; B108 descriptor disagreement; B109 limit; B110 target/toolchain; B111
-generated replay; I230 Clang; I231 Rust link/run; I232 publication; G218 Graph;
-and W114 Wasm. Diagnostics never echo source, paths, tool output, secrets, panic
-payloads, or pointers.
+generated replay; B112 SDK admission; I230 Clang; I231 Rust link/run; I232
+publication; I233 SDK publication; G218 Graph; and W114 Wasm. Diagnostics never
+echo source, paths, tool output, secrets, panic payloads, or pointers.
 
 The ordered nonclaims in every document deny resource/aggregate/pointer ABI,
 cross-boundary allocation, Wasm detours, dynamic loading, public execution,

--- a/scripts/quality.sh
+++ b/scripts/quality.sh
@@ -108,11 +108,13 @@ while IFS="$tab" read -r kind gate _rest; do
             for source in meaning ownership lifecycle control_flow records native_callable chars integers_i32 bytes_u8 explicit_mutation string_ops field_mutation while_loops inheritance; do
                 cargo run --locked -p semaprax -- check "examples/$source.spx"
             done
+            cargo run --locked -p semaprax -- check examples/calculator-rust/callback.spx
             ;;
         example-fmt)
             for source in meaning effects ownership lifecycle control_flow records native_callable chars integers_i32 bytes_u8 explicit_mutation string_ops field_mutation while_loops inheritance; do
                 cargo run --locked -p semaprax -- fmt "examples/$source.spx" --check
             done
+            cargo run --locked -p semaprax -- fmt examples/calculator-rust/callback.spx --check
             ;;
         *) echo "validated quality gate changed during dispatch: $gate" >&2; exit 2 ;;
     esac


### PR DESCRIPTION
`examples/calculator-rust/callback.spx` declares an `import rust fn` callback and the export that calls it, so it is the repository's only source-level example of the admitted bidirectional round trip. It was in neither the `example-checks` nor the `example-fmt` loop, leaving its verification and canonical formatting ungated. Both gates now cover it.

The builder already emits `SPX-B112` for SDK admission and `SPX-I233` for SDK publication, but the owned-diagnostic list in Native Rust Interoperability v1 omitted both. Record them so the list matches the code.

No admitted source form, type, ABI, descriptor, manifest, or generated artifact byte changed.

## Semantic change

Describe the meaning changed, affected stable IDs, completion-matrix rows, and trust-boundary impact.

## Evidence

- [ ] Canonical source round-trip remains deterministic.
- [ ] Agent graph/transaction behavior is covered where relevant.
- [ ] Success and stable diagnostic cases are tested.
- [ ] Native and Wasm behavior agree where runtime meaning changed.
- [ ] `scripts/quality.sh` or its platform-equivalent commands pass.
- [ ] Architecture, roadmap, changelog, and completion evidence are accurate.
- [ ] Public syntax/schema/protocol/CLI/manifest changes preserve a compatibility fixture or include a version bump and migration note.
- [ ] No capability, unsafe boundary, network access, or generated cache was introduced implicitly.

## Platforms exercised

List concrete hosts, simulators/devices, artifacts loaded, and behavior observed. A build without execution is not runtime evidence.
